### PR TITLE
Add per request sampling support.

### DIFF
--- a/jetstream_pt/engine.py
+++ b/jetstream_pt/engine.py
@@ -103,9 +103,7 @@ class PyTorchEngine(engine_api.Engine):
     self.pt_model = pt_model
     self.env = env
     self.default_dtype = jnp.bfloat16 if env.bf16_enable else jnp.float32
-    self.rng = jax.random.key(0).reshape(
-        1,
-    )
+    self.rng = jax.random.key(0)
     # For sampling
     self.splited_rngs = jax.random.split(self.rng, num=self.env.batch_size)
     self.weights = weights
@@ -467,6 +465,9 @@ class PyTorchEngine(engine_api.Engine):
 
       # Prefill only handle batch size of 1, therefore no need to use splitted rngs
       sampling = self._custom_sampling
+      rng = self.rng.reshape(
+          1,
+      )
     else:
       algorithm, temperature, topk, nucleus_topp = (
           self.env.sampling_algorithm,
@@ -475,11 +476,12 @@ class PyTorchEngine(engine_api.Engine):
           self.env.nucleus_topp,
       )
       sampling = self._sampling
+      rng = self.rng
 
     token = sampling(
         logits=logits,
         algorithm=algorithm,
-        rng=self.rng,
+        rng=rng,
         temperature=temperature,
         topk=topk,
         nucleus_topp=nucleus_topp,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,9 @@ from jetstream_pt import environment
 
 
 # pylint: disable-next=all
-def make_env_tiny(bf16_enable=True, env_data_update_fn=lambda _: None):
+def make_env_tiny(
+    bf16_enable=True, env_data_update_fn=lambda _: None, batch_size=1
+):
   torch_dtype = torch.bfloat16 if bf16_enable else torch.float32
   torch.set_default_dtype(torch_dtype)
   jax.config.update("jax_dynamic_shapes", False)
@@ -19,7 +21,7 @@ def make_env_tiny(bf16_enable=True, env_data_update_fn=lambda _: None):
   environment_data.cache_sequence_length = 128
   environment_data.bf16_enable = bf16_enable
   environment_data.model_type = "llama-2-tiny"
-  environment_data.batch_size = 1
+  environment_data.batch_size = batch_size
   environment_data.num_layers = config.n_layers
   environment_data.cache_shape = (
       1,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,16 +20,61 @@ import jax.numpy as jnp
 
 from jetstream_pt.third_party.llama import model_exportable
 from jetstream_pt.engine import PyTorchEngine
+from jetstream_pt.engine import DecodeState
+from jetstream_pt.engine import Prefix
 from tests import helpers
+from jetstream_pt import cache_manager
+
+
+class MockEngine(PyTorchEngine):
+
+  def _call_model_prefill(self, weights, tokens, input_indexes):
+    caches = [
+        cache_manager.KVCachePrefill(
+            self.env.quant_config.enable_kv_quantization
+        )
+        for _ in self.pt_model.layers
+    ]
+    # logits = jnp.ones((self.env.batch_size, 1), jnp.float32)
+    assert (
+        self.env.batch_size == 1
+    ), f"The batch size {self.env.batch_size} != 1"
+    logits = jnp.array([[0.5, 0.6, 0.7, 0.8]])
+    return logits, caches
+
+  def _call_model_generate(
+      self,
+      weights,
+      tokens,
+      input_indexes,
+      caches,
+      cache_scales,
+      mask,
+      start,
+      input_pos,
+      ragged_batch_index,
+      ragged_block_index,
+      page_token_indices,
+  ):
+    logits = jnp.array(
+        [
+            [[0.5, 0.6, 0.7, 0.8]],
+            # [[0.5, 0.6, 0.7, 0.8], [0.4, 0.3, 0.2, 0.1]],
+            [[0.4, 0.3, 0.2, 0.1]],
+        ]
+    )
+    return logits, caches, cache_scales
 
 
 class EngineTest(unittest.TestCase):
 
-  def setup(self):
-    env, model_arg = helpers.make_env_tiny(bf16_enable=True)
+  def setup(self, batch_size=1):
+    env, model_arg = helpers.make_env_tiny(
+        bf16_enable=True, batch_size=batch_size
+    )
     model_ours = model_exportable.Transformer(model_arg, env)
-    engine = PyTorchEngine(pt_model=model_ours, env=env)
-    engine.rng = jax.random.PRNGKey(0)
+    engine = MockEngine(pt_model=model_ours, env=env)
+    engine.rng = jax.random.key(0)
     return engine
 
   def test_sampling_2D(self):
@@ -37,14 +82,23 @@ class EngineTest(unittest.TestCase):
     engine = self.setup()
     self.assertEqual(engine.env.sampling_algorithm, "greedy")
     logits = jnp.array([[0.5, 0.6, 0.7, 0.8], [0.4, 0.3, 0.2, 0.1]])
-    token = engine._sampling(logits, batch_size=1)
+    token = engine._sampling(
+        logits, "greedy", engine.rng, temperature=1.0, topk=1, nucleus_topp=0.0
+    )
     self.assertEqual(token, jnp.array([[0]]))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
     # test weighted
     engine.env.sampling_algorithm = "weighted"
     engine.env.temperature = 5.0
-    token = engine._sampling(logits, batch_size=1)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        temperature=5.0,
+        topk=1,
+        nucleus_topp=0.0,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[0]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
@@ -52,21 +106,36 @@ class EngineTest(unittest.TestCase):
     engine.env.sampling_algorithm = "topk"
     engine.env.temperature = 5.0
     engine.env.topk = 4
-    token = engine._sampling(logits, batch_size=1)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        temperature=5.0,
+        topk=4,
+        nucleus_topp=0.0,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[0]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
     # test nucleus
     engine.env.sampling_algorithm = "nucleus"
-    engine.env.temperature = 0.0
+    engine.env.temperature = 1.0
     engine.env.nucleus_topp = 0.8
-    token = engine._sampling(logits, batch_size=1)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        temperature=0.0,
+        topk=1,
+        nucleus_topp=0.8,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[0]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
   def test_sampling_3D(self):
     # test greedy
-    engine = self.setup()
+    engine = self.setup(batch_size=2)
+
     self.assertEqual(engine.env.sampling_algorithm, "greedy")
     logits = jnp.array(
         [
@@ -74,14 +143,28 @@ class EngineTest(unittest.TestCase):
             [[0.5, 0.6, 0.7, 0.8], [0.4, 0.3, 0.2, 0.1]],
         ]
     )
-    token = engine._sampling(logits, batch_size=2)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        engine.env.temperature,
+        engine.env.topk,
+        engine.env.nucleus_topp,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[3], [0]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
     # test weighted
     engine.env.sampling_algorithm = "weighted"
     engine.env.temperature = 10.0
-    token = engine._sampling(logits, batch_size=2)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        engine.env.temperature,
+        engine.env.topk,
+        engine.env.nucleus_topp,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[3], [1]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
@@ -89,7 +172,14 @@ class EngineTest(unittest.TestCase):
     engine.env.sampling_algorithm = "topk"
     engine.env.temperature = 1.0
     engine.env.topk = 3
-    token = engine._sampling(logits, batch_size=2)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        engine.env.temperature,
+        engine.env.topk,
+        engine.env.nucleus_topp,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[1], [0]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
@@ -97,8 +187,349 @@ class EngineTest(unittest.TestCase):
     engine.env.sampling_algorithm = "nucleus"
     engine.env.temperature = 1.0
     engine.env.nucleus_topp = 0.8
-    token = engine._sampling(logits, batch_size=2)
+    token = engine._sampling(
+        logits,
+        engine.env.sampling_algorithm,
+        engine.rng,
+        engine.env.temperature,
+        engine.env.topk,
+        engine.env.nucleus_topp,
+    )
     self.assertTrue(jnp.array_equal(token, jnp.array([[3], [1]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+  def test_custom_sampling_3D(self):
+    engine = self.setup(batch_size=2)
+    engine.rng = jax.random.key(3)
+    engine.splited_rngs = jax.random.split(
+        engine.rng, num=engine.env.batch_size
+    )
+    engine.env.sampling_algorithm = ""
+
+    # Need a different engine of batch size of 1 to reshape the output
+    engine_b1 = self.setup()
+    engine_b1.rng = jax.random.key(3)
+    logits = jnp.array(
+        [
+            [[0.4, 0.3, 0.2, 0.1], [0.5, 0.6, 0.7, 0.8]],
+            [[0.5, 0.6, 0.7, 0.8], [0.4, 0.3, 0.2, 0.1]],
+        ]
+    )
+
+    # test greedy
+    token = engine._custom_sampling(
+        logits,
+        jnp.array([0, 0]),
+        engine.splited_rngs,
+        temperature=jnp.array([[0.0], [0.0]]),
+        topk=jnp.array([[0], [0]]),
+        nucleus_topp=jnp.array([[0.0], [0.0]]),
+    )
+    original_tokens = []
+    for i in range(2):
+      original_token = engine_b1._sampling(
+          logits[i],
+          "greedy",
+          engine.splited_rngs[i],
+          temperature=1.0,
+          topk=0,
+          nucleus_topp=0.0,
+      )
+      original_tokens.append(original_token)
+    original_tokens = jnp.concatenate(original_tokens)
+
+    print(f"custom sampling token {token} vs original tokens {original_tokens}")
+    self.assertTrue(jnp.array_equal(token, original_tokens))
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3], [0]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+    # test weighted
+    engine.env.sampling_algorithm = "weighted"
+    token = engine._custom_sampling(
+        logits,
+        jnp.array([1, 1]),
+        engine.splited_rngs,
+        temperature=jnp.array([1, 1]),
+        topk=jnp.array([0, 0]),
+        nucleus_topp=jnp.array([0.0, 0.0]),
+    )
+    original_tokens = []
+    for i in range(2):
+      original_token = engine_b1._sampling(
+          logits[i],
+          "weighted",
+          engine.splited_rngs[i],
+          temperature=1,
+          topk=0,
+          nucleus_topp=0.0,
+      )
+      original_tokens.append(original_token)
+    original_tokens = jnp.concatenate(original_tokens)
+
+    print(f"custom sampling token {token} vs original tokens {original_tokens}")
+    self.assertTrue(jnp.array_equal(token, original_tokens))
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3], [2]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+    # test topk
+    engine.env.sampling_algorithm = "topk"
+    token = engine._custom_sampling(
+        logits,
+        jnp.array([3, 3]),
+        engine.splited_rngs,
+        temperature=jnp.array([[1.0], [1.0]]),
+        topk=jnp.array([[3], [3]]),
+        nucleus_topp=jnp.array([[0.0], [0.0]]),
+    )
+    original_tokens = []
+    for i in range(2):
+      original_token = engine_b1._sampling(
+          logits[i],
+          "topk",
+          engine.splited_rngs[i],
+          temperature=1.0,
+          topk=3,
+          nucleus_topp=0.0,
+      )
+      original_tokens.append(original_token)
+    original_tokens = jnp.concatenate(original_tokens)
+
+    print(f"custom sampling token {token} vs original tokens {original_tokens}")
+    self.assertTrue(jnp.array_equal(token, original_tokens))
+    self.assertTrue(jnp.array_equal(token, jnp.array([[1], [2]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+    # test nucleus
+    engine.env.sampling_algorithm = "nucleus"
+    token = engine._custom_sampling(
+        logits,
+        jnp.array([2, 2]),
+        engine.splited_rngs,
+        temperature=jnp.array([[1.0], [1.0]]),
+        topk=jnp.array([[0], [0]]),
+        nucleus_topp=jnp.array([[0.8], [0.8]]),
+    )
+
+    original_tokens = []
+    for i in range(2):
+      original_token = engine_b1._sampling(
+          logits[i],
+          "nucleus",
+          engine.splited_rngs[i],
+          temperature=1.0,
+          topk=0,
+          nucleus_topp=0.8,
+      )
+      original_tokens.append(original_token)
+    original_tokens = jnp.concatenate(original_tokens)
+    print(f"custom sampling token {token} vs original tokens {original_tokens}")
+    self.assertTrue(jnp.array_equal(token, original_tokens))
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3], [2]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+    # test greedy + topk
+    token = engine._custom_sampling(
+        logits,
+        jnp.array([0, 3]),
+        engine.splited_rngs,
+        temperature=jnp.array([[0.0], [1.0]]),
+        topk=jnp.array([[0], [3]]),
+        nucleus_topp=jnp.array([[0.0], [0.0]]),
+    )
+    original_tokens = []
+
+    i = 0
+    original_token = engine_b1._sampling(
+        logits[i],
+        "greedy",
+        engine.splited_rngs[i],
+        temperature=0.0,
+        topk=0,
+        nucleus_topp=0.8,
+    )
+    original_tokens.append(original_token)
+
+    i = 1
+    original_token = engine_b1._sampling(
+        logits[i],
+        "topk",
+        engine.splited_rngs[i],
+        temperature=1.0,
+        topk=3,
+        nucleus_topp=0.0,
+    )
+    original_tokens.append(original_token)
+
+    original_tokens = jnp.concatenate(original_tokens)
+
+    print(f"custom sampling token {token} vs original tokens {original_tokens}")
+    self.assertTrue(jnp.array_equal(token, original_tokens))
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3], [2]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+  def test_prefill_with_custom_sampling(self):
+    engine = self.setup()
+    engine.env.sampling_algorithm = ""
+
+    # Inputs doesn't matter
+    params = jnp.zeros((1,), jnp.float32)
+    padded_tokens = jnp.zeros((1,), jnp.float32)
+    true_length = 1
+
+    # Greedy
+    # algorithm, temperature, topk, nucleus_topp
+    sampler = [0, 1.0, 3, 0.8]
+    prefix, _ = engine.prefill(
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
+        sampler=sampler,
+    )
+    token = prefix.token
+    print(f"Greedy output: {token}")
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+
+    print(
+        f"prefix sampler config {prefix.sampler_config} vs sampler {jnp.array(sampler)}"
+    )
+    self.assertAlmostEqual(
+        prefix.sampler_config.all(), jnp.array(sampler).all()
+    )
+
+    # Weighted
+    sampler = [1, 10.0, 3, 0.8]
+    prefix, _ = engine.prefill(
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
+        sampler=sampler,
+    )
+    token = prefix.token
+    print(f"Weighted output: {token}")
+    self.assertTrue(jnp.array_equal(token, jnp.array([[0]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+    self.assertAlmostEqual(
+        prefix.sampler_config.all(), jnp.array(sampler).all()
+    )
+
+    # Nucleus
+    sampler = [2, 1.0, 3, 0.0]
+    prefix, _ = engine.prefill(
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
+        sampler=sampler,
+    )
+    token = prefix.token
+    print(f"Topk output: {token}")
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+    self.assertAlmostEqual(
+        prefix.sampler_config.all(), jnp.array(sampler).all()
+    )
+
+    # Topk
+    sampler = [3, 1.0, 3, 0.8]
+    prefix, _ = engine.prefill(
+        params=params,
+        padded_tokens=padded_tokens,
+        true_length=true_length,
+        sampler=sampler,
+    )
+    token = prefix.token
+    print(f"Nucleus output: {token}")
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3]])))
+    self.assertTrue(jnp.isdtype(token, jnp.int32))
+    self.assertAlmostEqual(
+        prefix.sampler_config.all(), jnp.array(sampler).all()
+    )
+
+  def test_insert_no_wrap_with_custom_sampling(self):
+    engine = self.setup()
+    engine.env.sampling_algorithm = ""
+    engine.env.batch_size = 2
+    cache_shape = engine.env.cache_shape
+
+    sampler_config_raw = [0, 1.0, 3, 0.8]
+    sampler_config = jnp.array(sampler_config_raw)
+
+    prefill_cache_shape = (1, cache_shape[1], 16, cache_shape[3])
+    prefill_cache = []
+    for _ in range(engine.env.num_layers):
+      prefill_cache.append(
+          (
+              jnp.ones(prefill_cache_shape, dtype=jnp.bfloat16),
+              jnp.ones(prefill_cache_shape, dtype=jnp.bfloat16),
+          )
+      )
+
+    prefix = Prefix(
+        token=jnp.ones((1)),
+        caches=prefill_cache,
+        seq_len=16,
+        sampler_config=sampler_config,
+    )
+
+    doesnt_matter = jnp.array([0])
+    kv_cache = engine.env.make_caches_generate()
+    kv_cache = [c.state() for c in kv_cache]
+
+    decode_state = DecodeState(
+        tokens=jnp.zeros((engine.env.batch_size, 1)),
+        caches=kv_cache,
+        cache_scales=[doesnt_matter],
+        current_position=16,
+        lens=jnp.zeros((engine.env.batch_size, 1)),
+        start=jnp.zeros((engine.env.batch_size, 1)),
+        input_pos=jnp.zeros((engine.env.batch_size,)),
+        mask=jnp.zeros((engine.env.batch_size, 128)),
+        sampler_config=jnp.zeros((engine.env.batch_size, 4)),
+    )
+
+    # Insert to slot 1
+    result_decode_state = engine._insert_no_wrap(prefix, decode_state, slot=1)
+
+    self.assertAlmostEqual(
+        result_decode_state.tokens.all(), decode_state.tokens.all()
+    )
+    self.assertAlmostEqual(
+        result_decode_state.sampler_config.all(),
+        jnp.array([[0, 0, 0, 0], sampler_config_raw]).all(),
+    )
+
+  def test_decode_with_custom_sampling(self):
+    engine = self.setup(batch_size=2)
+    engine.rng = jax.random.key(3)
+    engine.splited_rngs = jax.random.split(
+        engine.rng, num=engine.env.batch_size
+    )
+    engine.env.sampling_algorithm = ""
+
+    # Inputs doesn't matter
+    doesnt_matter = jnp.array([0])
+    params = doesnt_matter
+
+    decode_state = DecodeState(
+        tokens=jnp.zeros((engine.env.batch_size, 1)),
+        caches=[doesnt_matter],
+        cache_scales=[doesnt_matter],
+        current_position=0,
+        lens=jnp.zeros((engine.env.batch_size, 1)),
+        start=doesnt_matter,
+        input_pos=jnp.zeros((engine.env.batch_size,)),
+        mask=jnp.zeros((engine.env.batch_size, 1)),
+        sampler_config=jnp.array([[0, 0.0, 0, 0.0], [3, 1.0, 3, 0.0]]),
+    )
+
+    # Topk + Weighted
+    # algorithm, temperature, topk, nucleus_topp
+    decode_state, _ = engine.generate_impl(
+        params=params, decode_state=decode_state
+    )
+    token = decode_state.tokens
+    print(f"Greedy output: {token}")
+    self.assertTrue(jnp.array_equal(token, jnp.array([[3], [2]])))
     self.assertTrue(jnp.isdtype(token, jnp.int32))
 
 


### PR DESCRIPTION
Supports sampling from request. When user set sampling_algorithm to '', each request can send the sampler config which contains algorithm, temperature, topk, nucleus to enable different sampling strategy. There will be a coming PR to enable it from JetStream side for the e2e workflow to work.