### PR TITLE
Add deepseek distils as options

### DIFF
--- a/jetstream_pt/fetch_models.py
+++ b/jetstream_pt/fetch_models.py
@@ -93,6 +93,8 @@ model_id_to_class = {
     "google/gemma-7b-it": _gemma_7b,
     "mistralai/Mixtral-8x7B-v0.1": _mixtral_87,
     "mistralai/Mixtral-8x7B-Instruct-v0.1": _mixtral_87,
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": _llama3_1_8b,
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": _llama3_3_70b,
 }
 
 

--- a/jetstream_pt/third_party/llama/model_exportable.py
+++ b/jetstream_pt/third_party/llama/model_exportable.py
@@ -344,6 +344,8 @@ class Transformer(ModuleBase):
           "meta-llama/Llama-3.2-1B-Instruct": "llama-3.2-1b",
           "meta-llama/Llama-3.3-70B": "llama-3.3-70b",
           "meta-llama/Llama-3.3-70B-Instruct": "llama-3.3-70b",
+          "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": "llama-3.1-8b",
+          "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": "llama-3.3-70b",
       }.get(model_id)
     assert name
     args = model_args.get_model_args(


### PR DESCRIPTION
Small change that allows directly using the recently released DeepSeek R1 Distils.

Tested on TPU v4-8 for "deepseek-ai/DeepSeek-R1-Distill-Llama-8B" and it worked.